### PR TITLE
Simplify GetLogger

### DIFF
--- a/init.go
+++ b/init.go
@@ -15,23 +15,15 @@ func init() {
 }
 
 func GetLogger() *logrus.Logger {
-	level := os.Getenv("TYK_LOGLEVEL")
-	if level == "" {
-		level = "info"
-	}
-
-	switch strings.ToLower(level) {
-	case "warn":
-		log.Level = logrus.WarnLevel
-	case "info":
-		log.Level = logrus.InfoLevel
-	case "debug":
-		log.Level = logrus.DebugLevel
+	switch strings.ToLower(os.Getenv("TYK_LOGLEVEL")) {
 	case "error":
 		log.Level = logrus.ErrorLevel
+	case "warn":
+		log.Level = logrus.WarnLevel
+	case "debug":
+		log.Level = logrus.DebugLevel
 	default:
 		log.Level = logrus.InfoLevel
 	}
-
 	return log
 }


### PR DESCRIPTION
"" and "info" can fall to the default case, so remove code. Also sort by
severity to keep everyone's sanity.